### PR TITLE
Typo on a portion of widget config netlify url inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To get dashboard support in Sanity Studio in general:
   - `buildHookId` - The id of a build hook you have created for your site within the Netlify administration panel (see *Site Settings > Build & Deploy > Continuous Deployment -> Build Hooks*).
   - `name` - The Netlify site name
   - `title` - Override the site name with a custom title
-  - `url` - Optionally override site deployment url. By default it is inferred to be `https://netlify-site-name-netlify.app`.
+  - `url` - Optionally override site deployment url. By default it is inferred to be `https://netlify-site-name.netlify.app`.
 
 ## Developing on this module
 


### PR DESCRIPTION
I believe it should be `https://netlify-site-name.netlify.app` and not `https://netlify-site-name-netlify.app` as that's what I observe as the url in the studio dasboard when using the plugin