### PR TITLE
Add support for new branch value in Site object

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ To get dashboard support in Sanity Studio in general:
   - `name` - The Netlify site name
   - `title` - Override the site name with a custom title
   - `url` - Optionally override site deployment url. By default it is inferred to be `https://netlify-site-name.netlify.app`.
+  - `branch` - Optionally pass the name of a branch to deploy
 
 ## Developing on this module
 

--- a/src/components/SiteItem/index.tsx
+++ b/src/components/SiteItem/index.tsx
@@ -10,16 +10,17 @@ interface Props {
 
 export const IMAGE_PULL_INTERVAL = 10000
 
-const getImageUrl = (siteId: string) => {
+const getImageUrl = (siteId: string, branchName?: string) => {
   const baseUrl = `https://api.netlify.com/api/v1/badges/${siteId}/deploy-status`
   const time = new Date().getTime()
+  const branch = `branch=${branchName}`
 
-  return `${baseUrl}?${time}`
+  return branchName ? `${baseUrl}?${time}&${branch}` : `${baseUrl}?${time}`
 }
 
-const useBadgeImage = (siteId: string) => {
-  const [src, setSrc] = useState(() => getImageUrl(siteId))
-  const update = useCallback(() => setSrc(getImageUrl(siteId)), [siteId])
+const useBadgeImage = (siteId: string, branchName?: string ) => {
+  const [src, setSrc] = useState(() => getImageUrl(siteId, branchName))
+  const update = useCallback(() => setSrc(getImageUrl(siteId, branchName)), [siteId])
 
   useEffect(() => {
     const interval = window.setInterval(update, IMAGE_PULL_INTERVAL)
@@ -42,9 +43,9 @@ const useDeploy = (site: Site, onDeploy: DeployAction, updateBadge: () => void) 
 const SiteItem: FunctionComponent<Props> = (props) => {
   const [hasBadgeError, setHasBadgeError] = useState(false)
   const {site, onDeploy} = props
-  const {id, name, title, url, adminUrl, buildHookId} = site
+  const {id, name, title, url, adminUrl, buildHookId, branch} = site
 
-  const [badge, updateBadge] = useBadgeImage(id)
+  const [badge, updateBadge] = useBadgeImage(id, branch)
   const handleDeploy = useDeploy(site, onDeploy, updateBadge)
   const handleBadgeError = () => {
     setHasBadgeError(true)

--- a/src/props.ts
+++ b/src/props.ts
@@ -23,6 +23,7 @@ export const props$ = (options: WidgetOptions) => {
     buildHookId: site.buildHookId,
     url: site.url || (site.name && `https://${site.name}.netlify.app/`),
     adminUrl: site.name && `https://app.netlify.com/sites/${site.name}`,
+    branch: site.branch
   }))
 
   const [onDeploy$, onDeploy] = createEventHandler<Site>()

--- a/src/props.ts
+++ b/src/props.ts
@@ -21,7 +21,7 @@ export const props$ = (options: WidgetOptions) => {
     name: site.name,
     title: site.title,
     buildHookId: site.buildHookId,
-    url: site.url || (site.name && `https://${site.name}.netlify.app/`),
+    url: site.url || (site.branch && `https://${site.branch}--${site.name}.netlify.app/`) || (site.name && `https://${site.name}.netlify.app/`),
     adminUrl: site.name && `https://app.netlify.com/sites/${site.name}`,
     branch: site.branch
   }))

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export interface SiteWidgetOption {
   title: string
   buildHookId: string
   url?: string
+  branch?: string
 }
 export interface WidgetOptions {
   title?: string
@@ -18,6 +19,7 @@ export interface Site {
   url?: string
   adminUrl?: string
   buildHookId: string
+  branch?: string
 }
 
 export interface Props {

--- a/test/SiteItem.test.tsx
+++ b/test/SiteItem.test.tsx
@@ -20,6 +20,7 @@ describe('SiteItem', () => {
   })
 
   const defaultSite: Site = {id: 'Id', title: 'Title', name: 'Name', buildHookId: 'BuildHookId'}
+  const siteWithBranch: Site = {id: 'Id', title: 'Title', name: 'Name', buildHookId: 'BuildHookId', branch: 'branch'}
 
   it('displays site title', () => {
     const {getByText} = render(<ThemeProvider scheme="light" theme={studioTheme}><SiteItem site={defaultSite} onDeploy={() => undefined} /></ThemeProvider>)
@@ -51,6 +52,13 @@ describe('SiteItem', () => {
       'src',
       `https://api.netlify.com/api/v1/badges/Id/deploy-status?${new Date().getTime()}`
     )
+  })
+
+  it('displays deploy badge for branch when branch name is used', () => {
+    const {getByAltText} = render(<ThemeProvider scheme="light" theme={studioTheme}><SiteItem site={siteWithBranch} onDeploy={() => undefined} /></ThemeProvider>)
+
+    const expectedSrc = `https://api.netlify.com/api/v1/badges/Id/deploy-status?${new Date().getTime()}&branch=branch`
+    expect(getByAltText('Badge')).toHaveAttribute('src', expectedSrc)
   })
 
   it('displays links to preview and site admin', () => {


### PR DESCRIPTION
This change is to add support for a new `branch` value to the `Site` object. Netlify has recently added support for passing `&branch=` as a URL parameter in the deploy badge status URL to show the state of your branch deploys. 

For example: `https://api.netlify.com/api/v1/badges/69350086-d20e-4b5a-84cf-bf367a848374/deploy-status?1658517492895&branch=build-sanity-drafts`