### PR TITLE
docs: update usage instructions for v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,15 @@ Ensure that you have followed install and usage instructions for [@sanity/dashbo
 Add it as a widget to @sanity/dashboard plugin in sanity.config.ts (or .js):
 
 ```js
+import { dashboardTool } from "@sanity/dashboard";
+import { netlifyWidget } from "sanity-plugin-dashboard-widget-netlify";
+
 export default createConfig({
   // ...
   plugins: [
     dashboardTool({
       widgets: [
-        {
-          name: 'netlify',
-          options: {
+        netlifyWidget({
             title: 'My Netlify deploys',
             sites: [
               {
@@ -52,8 +53,7 @@ export default createConfig({
                 url: 'https://my-sanity-deployment.com',
               }
             ]
-          }
-        }
+        })
       ]
     })
   ]


### PR DESCRIPTION
This PR updates README for usage instructions with v3 studio.

> V2 used an options-object to pass widget-specific configuration. In v3, options have been replaced by passing the same configuration directly to the widget-function.
>
> (https://github.com/sanity-io/dashboard)