### PR TITLE
fix (deps): Update peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,11 +107,11 @@
     "typescript": "^4.8.4"
   },
   "peerDependencies": {
-    "@sanity/dashboard": "^3.0.0",
+    "@sanity/dashboard": "^3.0.0 || ^4.0.0",
     "react": "^18",
     "react-dom": "^18",
     "sanity": "^3.0.0",
-    "styled-components": "^5.2"
+    "styled-components": "^5.2 || ^6.0 <= 6.1"
   },
   "engines": {
     "node": ">=14"


### PR DESCRIPTION
bump peer dependencies to include styled components v6 and @sanity/dashboard v4, which will allow the plugin to be used with the latest versions of sanity. 